### PR TITLE
Permissions update

### DIFF
--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -5,12 +5,11 @@
     "sdk": "org.gnome.Sdk",
     "command": "ghex",
     "finish-args": [
-        /* X11 + XShm */
-        "--share=ipc", "--socket=x11",
-        /* Wayland */
-        "--socket=wayland",
-        /* Filesystem */
-        "--filesystem=host"
+        "--filesystem=host",
+        "--device=dri",
+        "--share=ipc",
+        "--socket=fallback-x11",
+        "--socket=wayland"
     ],
     "modules": [
         {

--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -5,11 +5,13 @@
     "sdk": "org.gnome.Sdk",
     "command": "ghex",
     "finish-args": [
-        "--filesystem=host",
         "--device=dri",
+        "--filesystem=host",
+        "--filesystem=xdg-run/gvfsd",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--talk-name=org.gtk.vfs.*"
     ],
     "modules": [
         {


### PR DESCRIPTION
- Add missing permissions and cosmetics  
  DRI device was missing.  
  Switch from x11 to fallback-x11 socket.  
  Comments are not support in JSON, f-e-d-c will remove them, and those were too obvious and unnecessary.
- Allow GVfs access  
  This should make it possible to access GVfs resources with backend URIs.  
  One example is the admin backend using the admin:// URI.  
  References:
    - https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access
    - https://github.com/flathub/flathub/issues/2180
    - https://wiki.gnome.org/Projects/gvfs/backends