### PR TITLE
Bump to 42.0, add f-e-d-c, flathub.json, and switch to tarball releases

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": false
+}

--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -20,8 +20,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/ghex/3.41/ghex-3.41.1.tar.xz",
-                    "sha256": "8b79cf009eae5c47cad0ab53e2199c3a6fb2f3ab61877f359bed524770ee61f7",
+                    "url": "https://download.gnome.org/sources/ghex/42/ghex-42.0.tar.xz",
+                    "sha256": "2f2d7554ef128a6c68009d986394e204c31678c53e1d4a409f219098d4bfc9bb",
                     "x-checker-data": {
                         "type": "gnome",
                         "name": "ghex",

--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -17,12 +17,18 @@
         {
             "name": "ghex",
             "buildsystem": "meson",
-            "sources": [{
-                "type": "git",
-                "url": "https://gitlab.gnome.org/GNOME/ghex.git",
-                "tag": "3.41.1",
-                "commit": "2bd5cb649e40de5e3b197ce7666ee9bd14ae2c24"
-            }]
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/ghex/3.41/ghex-3.41.1.tar.xz",
+                    "sha256": "8b79cf009eae5c47cad0ab53e2199c3a6fb2f3ab61877f359bed524770ee61f7",
+                    "x-checker-data": {
+                        "type": "gnome",
+                        "name": "ghex",
+                        "stable-only": true
+                    }
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Add f-e-d-c support using the Gnome checker, which generates tarball source links.
The benefits of archive type source are that there's no need for network on rebuilds,
and the build process starts faster.
Add flathub.json to disable auto-merging PRs create by flathubbot.

Waiting on flathub/flatpak-external-data-checker#284