### PR TITLE
Update Ghex runtime to 46

### DIFF
--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -13,6 +13,15 @@
         "--filesystem=xdg-run/gvfsd",
         "--filesystem=host"
     ],
+    "cleanup": [
+        "/include",
+        "/lib/girepository-1.0",
+        "/lib/pkgconfig",
+        "/share/gir-1.0",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "ghex",

--- a/org.gnome.GHex.json
+++ b/org.gnome.GHex.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.GHex",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "ghex",
     "finish-args": [


### PR DESCRIPTION
- Update Ghex runtime to 46 because runtime 45 will be EOL on 2024-09-14.
- Remove some redundant files to reduce package size.